### PR TITLE
Fix bug in pbInput "readTag" and fix unit tests

### DIFF
--- a/UnitTest.pas
+++ b/UnitTest.pas
@@ -155,17 +155,17 @@ begin
   Assert(-1 = decodeZigZag64(1));
   Assert( 1 = decodeZigZag64(2));
   Assert(-2 = decodeZigZag64(3));
-  Assert($000000003FFFFFFF = decodeZigZag64($000000007FFFFFFE));
-  Assert($FFFFFFFFC0000000 = decodeZigZag64($000000007FFFFFFF));
-  Assert($000000007FFFFFFF = decodeZigZag64($00000000FFFFFFFE));
-  Assert($FFFFFFFF80000000 = decodeZigZag64($00000000FFFFFFFF));
-  Assert($7FFFFFFFFFFFFFFF = decodeZigZag64($FFFFFFFFFFFFFFFE));
-  Assert($8000000000000000 = decodeZigZag64($FFFFFFFFFFFFFFFF));
+  Assert(Int64($000000003FFFFFFF) = decodeZigZag64($000000007FFFFFFE));
+  Assert(Int64($FFFFFFFFC0000000) = decodeZigZag64($000000007FFFFFFF));
+  Assert(Int64($000000007FFFFFFF) = decodeZigZag64($00000000FFFFFFFE));
+  Assert(Int64($FFFFFFFF80000000) = decodeZigZag64($00000000FFFFFFFF));
+  Assert(Int64($7FFFFFFFFFFFFFFF) = decodeZigZag64($FFFFFFFFFFFFFFFE));
+  Assert(Int64($8000000000000000) = decodeZigZag64($FFFFFFFFFFFFFFFF));
 end;
 
 procedure TestReadString;
 const
-  TEST_string  = AnsiString('Тестовая строка');
+  TEST_string  = 'Тестовая строка';
   TEST_integer = 12345678;
   TEST_single  = 12345.123;
   TEST_double  = 1234567890.123;
@@ -173,7 +173,7 @@ var
   out_pb: TProtoBufOutput;
   in_pb: TProtoBufInput;
   tag, t: integer;
-  text: AnsiString;
+  text: string;
   int: integer;
   dbl: double;
   flt: single;

--- a/pbInput.pas
+++ b/pbInput.pas
@@ -178,7 +178,7 @@ end;
 
 function TProtoBufInput.readTag: integer;
 begin
-  if FPos <= FLen then
+  if FPos < FLen then
     FLastTag := readRawVarint32
   else
     FLastTag := 0;

--- a/pbTest.dpr
+++ b/pbTest.dpr
@@ -1,0 +1,16 @@
+program pbTest;
+
+{$APPTYPE CONSOLE}
+
+uses
+  SysUtils,
+  UnitTest in 'UnitTest.pas';
+
+begin
+  try
+    TestAll;
+  except
+    on E: Exception do
+      Writeln(E.ClassName, ': ', E.Message);
+  end;
+end.


### PR DESCRIPTION
Sometimes, parsing pb from memory was failed. So, I add test case to reproduce the bug and fix it.