### PR TITLE
Support for optional fields

### DIFF
--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -178,6 +178,7 @@ type
     PropertyName: string;
     PropertyType: string;
     function tagName: string;
+    function readOnlyDelphiProperty: Boolean;
   end;
 
 procedure ParsePropType(Prop: TProtoBufProperty; Proto: TProtoFile; out DelphiProp: TDelphiProperty);
@@ -611,7 +612,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
         if Prop.PropComment <> '' then
           SL.Add('    //' + Prop.PropComment);
         s := Format('    property %s: %s read F%s', [DelphiProp.PropertyName, DelphiProp.PropertyType, DelphiProp.PropertyName]);
-        if not(DelphiProp.IsList or DelphiProp.isObject) then
+        if not DelphiProp.readOnlyDelphiProperty then
           s := s + Format(' write F%s', [DelphiProp.PropertyName]);
         if Prop.PropOptions.HasValue['default'] then
           begin
@@ -697,6 +698,11 @@ begin
 end;
 
 { TDelphiProperty }
+
+function TDelphiProperty.readOnlyDelphiProperty: Boolean;
+begin
+  Result:= IsList or isObject;
+end;
 
 function TDelphiProperty.tagName: string;
 begin

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -530,16 +530,14 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
 var
   i: Integer;
 begin
-  SL.Add('');
   SL.Add('implementation');
 
   for i := 0 to Proto.ProtoBufMessages.Count - 1 do
     if not Proto.ProtoBufMessages[i].IsImported then
       begin
-        SL.Add('');
         WriteMessageToSL(Proto.ProtoBufMessages[i], SL);
+        SL.Add('');
       end;
-  SL.Add('');
   SL.Add('end.');
 end;
 

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -610,7 +610,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
         ParsePropType(Prop, Proto, DelphiProp);
         if Prop.PropComment <> '' then
           SL.Add('    //' + Prop.PropComment);
-        s := Format('    property %s:%s read F%s', [DelphiProp.PropertyName, DelphiProp.PropertyType, DelphiProp.PropertyName]);
+        s := Format('    property %s: %s read F%s', [DelphiProp.PropertyName, DelphiProp.PropertyType, DelphiProp.PropertyName]);
         if not(DelphiProp.IsList or DelphiProp.isObject) then
           s := s + Format(' write F%s', [DelphiProp.PropertyName]);
         if Prop.PropOptions.HasValue['default'] then

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -449,22 +449,25 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
 
+        SL.Add(Format('  if FieldHasValue[%s] then', [DelphiProp.tagName]));
         if not DelphiProp.IsList then
           begin
             if not DelphiProp.isComplex then
-              SL.Add(Format('  ProtoBuf.write%s(%s, F%s);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]))
+              SL.Add(Format('    ProtoBuf.write%s(%s, F%s);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]))
             else
               if not DelphiProp.isObject then
-                SL.Add(Format('  ProtoBuf.writeInt32(%s, Integer(F%s));', [DelphiProp.tagName, DelphiProp.PropertyName]))
+                SL.Add(Format('    ProtoBuf.writeInt32(%s, Integer(F%s));', [DelphiProp.tagName, DelphiProp.PropertyName]))
               else
                 begin
                   bNeedtmpBuf:= True;
-                  SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                  SL.Add('  try');
-                  SL.Add(Format('    F%s.SaveToBuf(tmpBuf);', [DelphiProp.PropertyName]));
-                  SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                  SL.Add('  finally');
-                  SL.Add('    tmpBuf.Free;');
+                  SL.Add('  begin');
+                  SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                  SL.Add('    try');
+                  SL.Add(Format('      F%s.SaveToBuf(tmpBuf);', [DelphiProp.PropertyName]));
+                  SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                  SL.Add('    finally');
+                  SL.Add('      tmpBuf.Free;');
+                  SL.Add('    end;');
                   SL.Add('  end;');
                 end;
           end
@@ -476,20 +479,22 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                   begin
                     bNeedtmpBuf:= True;
                     bNeedCounterVar:= True;
-                    SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                    SL.Add('  try');
-                    SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                    SL.Add(Format('      tmpBuf.write%s(F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.PropertyName]));
-                    SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                    SL.Add('  finally');
-                    SL.Add('    tmpBuf.Free;');
+                    SL.Add('  begin');
+                    SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                    SL.Add('    try');
+                    SL.Add(Format('      for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                    SL.Add(Format('        tmpBuf.write%s(F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.PropertyName]));
+                    SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                    SL.Add('    finally');
+                    SL.Add('      tmpBuf.Free;');
+                    SL.Add('    end;');
                     SL.Add('  end;');
                   end
                 else
                   begin
                     bNeedCounterVar:= True;
-                    SL.Add(Format('  for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                    SL.Add(Format('    ProtoBuf.write%s(%s, F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]));
+                    SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                    SL.Add(Format('      ProtoBuf.write%s(%s, F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]));
                   end;
               end
             else
@@ -499,24 +504,26 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                     begin
                       bNeedtmpBuf:= True;
                       bNeedCounterVar:= True;
-                      SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                      SL.Add('  try');
-                      SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('      tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
-                      SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                      SL.Add('  finally');
-                      SL.Add('    tmpBuf.Free;');
+                      SL.Add('  begin');
+                      SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                      SL.Add('    try');
+                      SL.Add(Format('      for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                      SL.Add(Format('        tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
+                      SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                      SL.Add('    finally');
+                      SL.Add('      tmpBuf.Free;');
+                      SL.Add('    end;');
                       SL.Add('  end;');
                     end
                   else
                     begin
                       bNeedCounterVar:= True;
-                      SL.Add(Format('  for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('    ProtoBuf.writeInt32(%s, Integer(F%s[i]));', [DelphiProp.tagName, DelphiProp.PropertyName]));
+                      SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                      SL.Add(Format('      ProtoBuf.writeInt32(%s, Integer(F%s[i]));', [DelphiProp.tagName, DelphiProp.PropertyName]));
                     end;
                 end
               else
-                SL.Add(Format('  F%s.SaveToBuf(ProtoBuf, %s);', [DelphiProp.PropertyName, DelphiProp.tagName]));
+                SL.Add(Format('    F%s.SaveToBuf(ProtoBuf, %s);', [DelphiProp.PropertyName, DelphiProp.tagName]));
           end;
       end;
 

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -304,7 +304,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         if DelphiProp.IsList or DelphiProp.isObject then
           SL.Add(Format('  F%s := %s.Create;', [DelphiProp.PropertyName, DelphiProp.PropertyType]));
         if Prop.PropOptions.HasValue['default'] then
-          SL.Add(Format('  F%s := %s;', [DelphiProp.PropertyName, ReQuoteStr(Prop.PropOptions.Value['default'])]));
+          SL.Add(Format('  %s%s := %s;', [IfThen(DelphiProp.readOnlyDelphiProperty, 'F', ''), DelphiProp.PropertyName, ReQuoteStr(Prop.PropOptions.Value['default'])]));
         if Prop.PropKind = ptRequired then
           SL.Add(Format('  RegisterRequiredField(%s);', [DelphiProp.tagName]));
       end;

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -595,7 +595,6 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
         SL.Add('    destructor Destroy; override;');
         SL.Add('');
       end;
-    SL.Add('');
     for i := 0 to ProtoMsg.Count - 1 do
       begin
         Prop := ProtoMsg[i];

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -353,10 +353,10 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         if not DelphiProp.IsList then
           begin
             if not DelphiProp.isComplex then
-              SL.Add(Format('      F%s := ProtoBuf.read%s;', [DelphiProp.PropertyName, GetProtoBufMethodForScalarType(Prop)]))
+              SL.Add(Format('      %s := ProtoBuf.read%s;', [DelphiProp.PropertyName, GetProtoBufMethodForScalarType(Prop)]))
             else
               if not DelphiProp.isObject then
-                SL.Add(Format('      F%s := %s(ProtoBuf.readEnum);', [DelphiProp.PropertyName, DelphiProp.PropertyType]))
+                SL.Add(Format('      %s := %s(ProtoBuf.readEnum);', [DelphiProp.PropertyName, DelphiProp.PropertyType]))
               else
                 begin
                   bNeedtmpBuf:= True;
@@ -633,8 +633,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
-        s := Format('    F%s: %s;', [DelphiProp.PropertyName, DelphiProp.PropertyType]);
-        SL.Add(s);
+        SL.Add(Format('    F%s: %s;', [DelphiProp.PropertyName, DelphiProp.PropertyType]));
       end;
     SL.Add('');
     //property setters

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -609,7 +609,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
         if Prop.PropComment <> '' then
-          SL.Add('//' + Prop.PropComment);
+          SL.Add('    //' + Prop.PropComment);
         s := Format('    property %s:%s read F%s', [DelphiProp.PropertyName, DelphiProp.PropertyType, DelphiProp.PropertyName]);
         if not(DelphiProp.IsList or DelphiProp.isObject) then
           s := s + Format(' write F%s', [DelphiProp.PropertyName]);

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -550,6 +550,8 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
+        if DelphiProp.readOnlyDelphiProperty then
+          Continue;
         SL.Add(Format('procedure T%s.Set%s(Tag: Integer; const Value: %s);',
           [ProtoMsg.Name, DelphiProp.PropertyName, DelphiProp.PropertyType]));
         SL.Add('begin');
@@ -640,6 +642,8 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
+        if DelphiProp.readOnlyDelphiProperty then
+          Continue;
         s := Format('    procedure Set%s(Tag: Integer; const Value: %s);', [DelphiProp.PropertyName, DelphiProp.PropertyType]);
         SL.Add(s);
       end;

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -293,7 +293,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     DelphiProp: TDelphiProperty;
     i: Integer;
   begin
-    SL.Add('');
     SL.Add(Format('constructor T%s.Create;', [ProtoMsg.Name]));
     SL.Add('begin');
     SL.Add('  inherited;');
@@ -322,6 +321,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       end;
     SL.Add('  inherited;');
     SL.Add('end;');
+    SL.Add('');
   end;
 
   procedure WriteLoadProc(ProtoMsg: TProtoBufMessage; SL: TStrings);
@@ -332,7 +332,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     bNeedtmpBuf: Boolean;
   begin
     bNeedtmpBuf:= False;
-    SL.Add('');
     SL.Add(Format('function T%s.LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: Integer; WireType: Integer): Boolean;', [ProtoMsg.Name]));
     iInsertVarBlock:= SL.Count;
     SL.Add('begin');
@@ -424,6 +423,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     SL.Add('    Result:= False;');
     SL.Add('  end;');
     SL.Add('end;');
+    SL.Add('');
     if bNeedtmpBuf then
       begin
         SL.Insert(iInsertVarBlock, '  tmpBuf: TProtoBufInput;');
@@ -440,7 +440,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
   begin
     bNeedtmpBuf:= False;
     bNeedCounterVar:= False;
-    SL.Add('');
     SL.Add(Format('procedure T%s.SaveFieldsToBuf(ProtoBuf: TProtoBufOutput);', [ProtoMsg.Name]));
     iInsertVarBlock:= sl.Count;
     SL.Add('begin');
@@ -522,6 +521,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       end;
 
     SL.Add('end;');
+    SL.Add('');
 
     if bNeedtmpBuf or bNeedCounterVar then
       begin
@@ -541,6 +541,8 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       Exit;
     bNeedConstructor := MsgNeedConstructor(ProtoMsg, Proto);
 
+    SL.Add(Format('{ T%s }', [ProtoMsg.Name]));
+    SL.Add('');
     if bNeedConstructor then
       WriteConstructor(ProtoMsg, SL);
     WriteLoadProc(ProtoMsg, SL);
@@ -551,13 +553,11 @@ var
   i: Integer;
 begin
   SL.Add('implementation');
+  SL.Add('');
 
   for i := 0 to Proto.ProtoBufMessages.Count - 1 do
     if not Proto.ProtoBufMessages[i].IsImported then
-      begin
         WriteMessageToSL(Proto.ProtoBufMessages[i], SL);
-        SL.Add('');
-      end;
   SL.Add('end.');
 end;
 

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -29,7 +29,7 @@ uses
 function ProtoPropTypeToDelphiType(const PropTypeName: string): string;
 var
   StandartType: TScalarPropertyType;
-  i: integer;
+  i: Integer;
 begin
   StandartType := StrToPropertyType(PropTypeName);
   case StandartType of
@@ -38,7 +38,7 @@ begin
     sptFloat:
       Result := 'Single';
     sptInt32:
-      Result := 'integer';
+      Result := 'Integer';
     sptInt64:
       Result := 'Int64';
     sptuInt32:
@@ -46,15 +46,15 @@ begin
     sptUint64:
       Result := 'UInt64';
     sptSInt32:
-      Result := 'integer';
+      Result := 'Integer';
     sptSInt64:
       Result := 'Int64';
     sptFixed32:
-      Result := 'integer';
+      Result := 'Integer';
     sptFixed64:
       Result := 'Int64';
     sptSFixed32:
-      Result := 'integer';
+      Result := 'Integer';
     sptSFixed64:
       Result := 'Int64';
     sptBool:
@@ -205,7 +205,7 @@ end;
 
 function MsgNeedConstructor(ProtoMsg: TProtoBufMessage; Proto: TProtoFile): Boolean;
 var
-  i: integer;
+  i: Integer;
   DelphiProp: TDelphiProperty;
   Prop: TProtoBufProperty;
 begin
@@ -222,7 +222,7 @@ end;
 
 function MsgContainsRepeatedFields(ProtoMsg: TProtoBufMessage): Boolean;
 var
-  i: integer;
+  i: Integer;
 begin
   Result := False;
   for i := 0 to ProtoMsg.Count - 1 do
@@ -289,7 +289,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
   var
     Prop: TProtoBufProperty;
     DelphiProp: TDelphiProperty;
-    i: integer;
+    i: Integer;
   begin
     SL.Add('');
     SL.Add(Format('constructor T%s.Create;', [ProtoMsg.Name]));
@@ -324,12 +324,12 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
 
   procedure WriteLoadProc(ProtoMsg: TProtoBufMessage; SL: TStrings);
   var
-    i: integer;
+    i: Integer;
     Prop: TProtoBufProperty;
     DelphiProp: TDelphiProperty;
   begin
     SL.Add('');
-    SL.Add(Format('function T%s.LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: integer; WireType: integer): Boolean;', [ProtoMsg.Name]));
+    SL.Add(Format('function T%s.LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: Integer; WireType: Integer): Boolean;', [ProtoMsg.Name]));
     if MsgNeedConstructor(ProtoMsg, Proto) then
       begin
         SL.Add('var');
@@ -423,7 +423,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
 
   procedure WriteSaveProc(ProtoMsg: TProtoBufMessage; SL: TStrings);
   var
-    i: integer;
+    i: Integer;
     Prop: TProtoBufProperty;
     DelphiProp: TDelphiProperty;
   begin
@@ -435,7 +435,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         if MsgNeedConstructor(ProtoMsg, Proto) then
           SL.Add('  tmpBuf: TProtoBufOutput;');
         if MsgContainsRepeatedFields(ProtoMsg) then
-          SL.Add('  i: integer;');
+          SL.Add('  i: Integer;');
       end;
     SL.Add('begin');
     SL.Add('  inherited;');
@@ -450,7 +450,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
               SL.Add(Format('  ProtoBuf.write%s(%d, F%s);', [GetProtoBufMethodForScalarType(Prop), Prop.PropFieldNum, DelphiProp.PropertyName]))
             else
               if not DelphiProp.isObject then
-                SL.Add(Format('  ProtoBuf.writeInt32(%d, integer(F%s));', [Prop.PropFieldNum, DelphiProp.PropertyName]))
+                SL.Add(Format('  ProtoBuf.writeInt32(%d, Integer(F%s));', [Prop.PropFieldNum, DelphiProp.PropertyName]))
               else
                 begin
                   SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
@@ -491,7 +491,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                       SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
                       SL.Add('  try');
                       SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('      tmpBuf.writeRawVarint32(integer(F%s[i]));', [DelphiProp.PropertyName]));
+                      SL.Add(Format('      tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
                       SL.Add(Format('    ProtoBuf.writeMessage(%d, tmpBuf);', [Prop.PropFieldNum]));
                       SL.Add('  finally');
                       SL.Add('    tmpBuf.Free;');
@@ -500,7 +500,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                   else
                     begin
                       SL.Add(Format('  for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('    ProtoBuf.writeInt32(%d, integer(F%s[i]));', [Prop.PropFieldNum, DelphiProp.PropertyName]));
+                      SL.Add(Format('    ProtoBuf.writeInt32(%d, Integer(F%s[i]));', [Prop.PropFieldNum, DelphiProp.PropertyName]));
                     end;
                 end
               else
@@ -526,7 +526,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
   end;
 
 var
-  i: integer;
+  i: Integer;
 begin
   SL.Add('');
   SL.Add('implementation');
@@ -544,7 +544,7 @@ end;
 procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TStrings);
   procedure WriteEnumToSL(ProtoEnum: TProtoBufEnum; SL: TStrings);
   var
-    i: integer;
+    i: Integer;
     s: string;
   begin
     if ProtoEnum.IsImported then
@@ -564,7 +564,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
 
   procedure WriteMessageToSL(ProtoMsg: TProtoBufMessage; SL: TStrings);
   var
-    i: integer;
+    i: Integer;
     Prop: TProtoBufProperty;
     DelphiProp: TDelphiProperty;
     s, sdefValue: string;
@@ -585,7 +585,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
         SL.Add(s);
       end;
     SL.Add('  strict protected');
-    SL.Add('    function LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: integer; WireType: integer): Boolean; override;');
+    SL.Add('    function LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: Integer; WireType: Integer): Boolean; override;');
     SL.Add('    procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); override;');
 
     SL.Add('  public');
@@ -618,7 +618,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
   end;
 
 var
-  i: integer;
+  i: Integer;
 begin
   SL.Add(Format('unit %s;', [Proto.Name]));
   SL.Add('');
@@ -668,7 +668,7 @@ procedure TProtoBufGenerator.Generate(const InputFile, OutputDir: string; Encodi
 var
   Proto: TProtoFile;
   SL: TStringList;
-  iPos: integer;
+  iPos: Integer;
 begin
   SL := TStringList.Create;
   try

--- a/uAbstractProtoBufClasses.pas
+++ b/uAbstractProtoBufClasses.pas
@@ -32,7 +32,7 @@ type
     procedure AfterLoad; virtual;
 
     function LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: integer; WireType: integer): Boolean; virtual;
-    procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); virtual; abstract;
+    procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); virtual;
   public
     constructor Create; virtual;
     destructor Destroy; override;
@@ -209,6 +209,12 @@ end;
 procedure TAbstractProtoBufClass.RegisterRequiredField(Tag: integer);
 begin
   AddFieldState(Tag, [fsRequired]);
+end;
+
+procedure TAbstractProtoBufClass.SaveFieldsToBuf(ProtoBuf: TProtoBufOutput);
+begin
+  if not AllRequiredFieldsValid then
+    raise EStreamError.CreateFmt('Saving %s: not all required fields have been set', [ClassName]);
 end;
 
 procedure TAbstractProtoBufClass.SaveToBuf(ProtoBuf: TProtoBufOutput);

--- a/uAbstractProtoBufClasses.pas
+++ b/uAbstractProtoBufClasses.pas
@@ -27,7 +27,6 @@ type
   strict protected
     procedure AddLoadedField(Tag: integer);
     procedure RegisterRequiredField(Tag: integer);
-    function IsAllRequiredLoaded: Boolean;
 
     procedure BeforeLoad; virtual;
     procedure AfterLoad; virtual;
@@ -46,6 +45,8 @@ type
 
     procedure LoadFromBuf(ProtoBuf: TProtoBufInput);
     procedure SaveToBuf(ProtoBuf: TProtoBufOutput);
+
+    function AllRequiredFieldsValid: Boolean;
 
     property FieldHasValue[Tag: Integer]: Boolean read GetFieldHasValue write SetFieldHasValue;
   end;
@@ -131,7 +132,7 @@ begin
   Result:= fsHasValue in GetFieldState(Tag);
 end;
 
-function TAbstractProtoBufClass.IsAllRequiredLoaded: Boolean;
+function TAbstractProtoBufClass.AllRequiredFieldsValid: Boolean;
 var
   state: TFieldState;
 begin
@@ -161,8 +162,8 @@ begin
         AddLoadedField(FieldNumber);
       Tag := ProtoBuf.readTag;
     end;
-  if not IsAllRequiredLoaded then
-    raise EStreamError.Create('not enought fields');
+  if not AllRequiredFieldsValid then
+    raise EStreamError.CreateFmt('Loading %s: not all required fields have been loaded', [ClassName]);
 
   AfterLoad;
 end;


### PR DESCRIPTION
I have added support for optional fields via a new FieldHasValue indexed property that is fed by a new FieldStates dictionary which replaced the previous RequiredFields dictionary. An exception is now also raised when saving a message which has not values for all required fields. FieldHasValue is automatically set in property setters which are now generated too. For submessages and lists the caller has to set FieldHasValue manually.
I've also tried to minimize and beautify the generated code.