### PR TITLE
oneOf and enum option allow_alias

### DIFF
--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -449,22 +449,25 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
 
+        SL.Add(Format('  if FieldHasValue[%s] then', [DelphiProp.tagName]));
         if not DelphiProp.IsList then
           begin
             if not DelphiProp.isComplex then
-              SL.Add(Format('  ProtoBuf.write%s(%s, F%s);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]))
+              SL.Add(Format('    ProtoBuf.write%s(%s, F%s);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]))
             else
               if not DelphiProp.isObject then
-                SL.Add(Format('  ProtoBuf.writeInt32(%s, Integer(F%s));', [DelphiProp.tagName, DelphiProp.PropertyName]))
+                SL.Add(Format('    ProtoBuf.writeInt32(%s, Integer(F%s));', [DelphiProp.tagName, DelphiProp.PropertyName]))
               else
                 begin
                   bNeedtmpBuf:= True;
-                  SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                  SL.Add('  try');
-                  SL.Add(Format('    F%s.SaveToBuf(tmpBuf);', [DelphiProp.PropertyName]));
-                  SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                  SL.Add('  finally');
-                  SL.Add('    tmpBuf.Free;');
+                  SL.Add('  begin');
+                  SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                  SL.Add('    try');
+                  SL.Add(Format('      F%s.SaveToBuf(tmpBuf);', [DelphiProp.PropertyName]));
+                  SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                  SL.Add('    finally');
+                  SL.Add('      tmpBuf.Free;');
+                  SL.Add('    end;');
                   SL.Add('  end;');
                 end;
           end
@@ -476,20 +479,22 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                   begin
                     bNeedtmpBuf:= True;
                     bNeedCounterVar:= True;
-                    SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                    SL.Add('  try');
-                    SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                    SL.Add(Format('      tmpBuf.write%s(F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.PropertyName]));
-                    SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                    SL.Add('  finally');
-                    SL.Add('    tmpBuf.Free;');
+                    SL.Add('  begin');
+                    SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                    SL.Add('    try');
+                    SL.Add(Format('      for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                    SL.Add(Format('        tmpBuf.write%s(F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.PropertyName]));
+                    SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                    SL.Add('    finally');
+                    SL.Add('      tmpBuf.Free;');
+                    SL.Add('    end;');
                     SL.Add('  end;');
                   end
                 else
                   begin
                     bNeedCounterVar:= True;
-                    SL.Add(Format('  for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                    SL.Add(Format('    ProtoBuf.write%s(%s, F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]));
+                    SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                    SL.Add(Format('      ProtoBuf.write%s(%s, F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.tagName, DelphiProp.PropertyName]));
                   end;
               end
             else
@@ -499,24 +504,26 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                     begin
                       bNeedtmpBuf:= True;
                       bNeedCounterVar:= True;
-                      SL.Add('  tmpBuf:=TProtoBufOutput.Create;');
-                      SL.Add('  try');
-                      SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('      tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
-                      SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                      SL.Add('  finally');
-                      SL.Add('    tmpBuf.Free;');
+                      SL.Add('  begin');
+                      SL.Add('    tmpBuf:=TProtoBufOutput.Create;');
+                      SL.Add('    try');
+                      SL.Add(Format('      for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                      SL.Add(Format('        tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
+                      SL.Add(Format('      ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
+                      SL.Add('    finally');
+                      SL.Add('      tmpBuf.Free;');
+                      SL.Add('    end;');
                       SL.Add('  end;');
                     end
                   else
                     begin
                       bNeedCounterVar:= True;
-                      SL.Add(Format('  for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
-                      SL.Add(Format('    ProtoBuf.writeInt32(%s, Integer(F%s[i]));', [DelphiProp.tagName, DelphiProp.PropertyName]));
+                      SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
+                      SL.Add(Format('      ProtoBuf.writeInt32(%s, Integer(F%s[i]));', [DelphiProp.tagName, DelphiProp.PropertyName]));
                     end;
                 end
               else
-                SL.Add(Format('  F%s.SaveToBuf(ProtoBuf, %s);', [DelphiProp.PropertyName, DelphiProp.tagName]));
+                SL.Add(Format('    F%s.SaveToBuf(ProtoBuf, %s);', [DelphiProp.PropertyName, DelphiProp.tagName]));
           end;
       end;
 

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -353,10 +353,10 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
         if not DelphiProp.IsList then
           begin
             if not DelphiProp.isComplex then
-              SL.Add(Format('      F%s := ProtoBuf.read%s;', [DelphiProp.PropertyName, GetProtoBufMethodForScalarType(Prop)]))
+              SL.Add(Format('      %s := ProtoBuf.read%s;', [DelphiProp.PropertyName, GetProtoBufMethodForScalarType(Prop)]))
             else
               if not DelphiProp.isObject then
-                SL.Add(Format('      F%s := %s(ProtoBuf.readEnum);', [DelphiProp.PropertyName, DelphiProp.PropertyType]))
+                SL.Add(Format('      %s := %s(ProtoBuf.readEnum);', [DelphiProp.PropertyName, DelphiProp.PropertyType]))
               else
                 begin
                   bNeedtmpBuf:= True;
@@ -633,8 +633,7 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
-        s := Format('    F%s: %s;', [DelphiProp.PropertyName, DelphiProp.PropertyType]);
-        SL.Add(s);
+        SL.Add(Format('    F%s: %s;', [DelphiProp.PropertyName, DelphiProp.PropertyType]));
       end;
     SL.Add('');
     //property setters

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -550,6 +550,8 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
+        if DelphiProp.readOnlyDelphiProperty then
+          Continue;
         SL.Add(Format('procedure T%s.Set%s(Tag: Integer; const Value: %s);',
           [ProtoMsg.Name, DelphiProp.PropertyName, DelphiProp.PropertyType]));
         SL.Add('begin');
@@ -640,6 +642,8 @@ procedure TProtoBufGenerator.GenerateInterfaceSection(Proto: TProtoFile; SL: TSt
       begin
         Prop := ProtoMsg[i];
         ParsePropType(Prop, Proto, DelphiProp);
+        if DelphiProp.readOnlyDelphiProperty then
+          Continue;
         s := Format('    procedure Set%s(Tag: Integer; const Value: %s);', [DelphiProp.PropertyName, DelphiProp.PropertyType]);
         SL.Add(s);
       end;

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -293,7 +293,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     DelphiProp: TDelphiProperty;
     i: Integer;
   begin
-    SL.Add('');
     SL.Add(Format('constructor T%s.Create;', [ProtoMsg.Name]));
     SL.Add('begin');
     SL.Add('  inherited;');
@@ -322,6 +321,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       end;
     SL.Add('  inherited;');
     SL.Add('end;');
+    SL.Add('');
   end;
 
   procedure WriteLoadProc(ProtoMsg: TProtoBufMessage; SL: TStrings);
@@ -332,7 +332,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     bNeedtmpBuf: Boolean;
   begin
     bNeedtmpBuf:= False;
-    SL.Add('');
     SL.Add(Format('function T%s.LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: Integer; WireType: Integer): Boolean;', [ProtoMsg.Name]));
     iInsertVarBlock:= SL.Count;
     SL.Add('begin');
@@ -424,6 +423,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
     SL.Add('    Result:= False;');
     SL.Add('  end;');
     SL.Add('end;');
+    SL.Add('');
     if bNeedtmpBuf then
       begin
         SL.Insert(iInsertVarBlock, '  tmpBuf: TProtoBufInput;');
@@ -440,7 +440,6 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
   begin
     bNeedtmpBuf:= False;
     bNeedCounterVar:= False;
-    SL.Add('');
     SL.Add(Format('procedure T%s.SaveFieldsToBuf(ProtoBuf: TProtoBufOutput);', [ProtoMsg.Name]));
     iInsertVarBlock:= sl.Count;
     SL.Add('begin');
@@ -522,6 +521,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       end;
 
     SL.Add('end;');
+    SL.Add('');
 
     if bNeedtmpBuf or bNeedCounterVar then
       begin
@@ -541,6 +541,8 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
       Exit;
     bNeedConstructor := MsgNeedConstructor(ProtoMsg, Proto);
 
+    SL.Add(Format('{ T%s }', [ProtoMsg.Name]));
+    SL.Add('');
     if bNeedConstructor then
       WriteConstructor(ProtoMsg, SL);
     WriteLoadProc(ProtoMsg, SL);
@@ -551,13 +553,11 @@ var
   i: Integer;
 begin
   SL.Add('implementation');
+  SL.Add('');
 
   for i := 0 to Proto.ProtoBufMessages.Count - 1 do
     if not Proto.ProtoBufMessages[i].IsImported then
-      begin
         WriteMessageToSL(Proto.ProtoBufMessages[i], SL);
-        SL.Add('');
-      end;
   SL.Add('end.');
 end;
 

--- a/uAbstractProtoBufClasses.pas
+++ b/uAbstractProtoBufClasses.pas
@@ -32,7 +32,7 @@ type
     procedure AfterLoad; virtual;
 
     function LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: integer; WireType: integer): Boolean; virtual;
-    procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); virtual; abstract;
+    procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); virtual;
   public
     constructor Create; virtual;
     destructor Destroy; override;
@@ -209,6 +209,12 @@ end;
 procedure TAbstractProtoBufClass.RegisterRequiredField(Tag: integer);
 begin
   AddFieldState(Tag, [fsRequired]);
+end;
+
+procedure TAbstractProtoBufClass.SaveFieldsToBuf(ProtoBuf: TProtoBufOutput);
+begin
+  if not AllRequiredFieldsValid then
+    raise EStreamError.CreateFmt('Saving %s: not all required fields have been set', [ClassName]);
 end;
 
 procedure TAbstractProtoBufClass.SaveToBuf(ProtoBuf: TProtoBufOutput);

--- a/uAbstractProtoBufClasses.pas
+++ b/uAbstractProtoBufClasses.pas
@@ -27,7 +27,6 @@ type
   strict protected
     procedure AddLoadedField(Tag: integer);
     procedure RegisterRequiredField(Tag: integer);
-    function IsAllRequiredLoaded: Boolean;
 
     procedure BeforeLoad; virtual;
     procedure AfterLoad; virtual;
@@ -46,6 +45,8 @@ type
 
     procedure LoadFromBuf(ProtoBuf: TProtoBufInput);
     procedure SaveToBuf(ProtoBuf: TProtoBufOutput);
+
+    function AllRequiredFieldsValid: Boolean;
 
     property FieldHasValue[Tag: Integer]: Boolean read GetFieldHasValue write SetFieldHasValue;
   end;
@@ -131,7 +132,7 @@ begin
   Result:= fsHasValue in GetFieldState(Tag);
 end;
 
-function TAbstractProtoBufClass.IsAllRequiredLoaded: Boolean;
+function TAbstractProtoBufClass.AllRequiredFieldsValid: Boolean;
 var
   state: TFieldState;
 begin
@@ -161,8 +162,8 @@ begin
         AddLoadedField(FieldNumber);
       Tag := ProtoBuf.readTag;
     end;
-  if not IsAllRequiredLoaded then
-    raise EStreamError.Create('not enought fields');
+  if not AllRequiredFieldsValid then
+    raise EStreamError.CreateFmt('Loading %s: not all required fields have been loaded', [ClassName]);
 
   AfterLoad;
 end;


### PR DESCRIPTION
oneof field are now fully supported. 
* The code generator will generate a local enum for each oneof property which used by the <fieldname>_Oneof property. 
* This property can be set and retrieved to check which oneof field is set. 
* The generated LoadProc will also set the _Oneof property which ensures that all other fields will get their FieldHasValue cleared
* unit tests for the parsing of oneof fields have been added

also enums now support the allow_alias option
* support for parser added
* unit tests added for the parsing
* does not affect code generation as Delphi already supports aliases in enums