### PR TITLE
Bugfix for reused tmpBuf in generated SaveFieldsToBuf methods

### DIFF
--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -489,6 +489,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                     bNeedtmpBuf:= True;
                     bNeedCounterVar:= True;
                     SL.Add(       '  begin');
+                    SL.Add(       '    tmpBuf.Clear;');
                     SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
                     SL.Add(Format('      tmpBuf.write%s(F%s[i]);', [GetProtoBufMethodForScalarType(Prop), DelphiProp.PropertyName]));
                     SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
@@ -509,6 +510,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
                       bNeedtmpBuf:= True;
                       bNeedCounterVar:= True;
                       SL.Add(       '  begin');
+                      SL.Add(       '    tmpBuf.Clear;');
                       SL.Add(Format('    for i := 0 to F%s.Count-1 do', [DelphiProp.PropertyName]));
                       SL.Add(Format('      tmpBuf.writeRawVarint32(Integer(F%s[i]));', [DelphiProp.PropertyName]));
                       SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));

--- a/Generator/uProtoBufGenerator.pas
+++ b/Generator/uProtoBufGenerator.pas
@@ -477,10 +477,7 @@ procedure TProtoBufGenerator.GenerateImplementationSection(Proto: TProtoFile; SL
               else
                 begin
                   bNeedtmpBuf:= True;
-                  SL.Add(       '  begin');
-                  SL.Add(Format('    F%s.SaveToBuf(tmpBuf);', [DelphiProp.PropertyName]));
-                  SL.Add(Format('    ProtoBuf.writeMessage(%s, tmpBuf);', [DelphiProp.tagName]));
-                  SL.Add(       '  end;');
+                  SL.Add(Format('    SaveMessageFieldToBuf(F%s, %s, tmpBuf, ProtoBuf);', [DelphiProp.PropertyName, DelphiProp.tagName]));
                 end;
           end
         else

--- a/uAbstractProtoBufClasses.pas
+++ b/uAbstractProtoBufClasses.pas
@@ -40,6 +40,7 @@ type
 
     function LoadSingleFieldFromBuf(ProtoBuf: TProtoBufInput; FieldNumber: integer; WireType: integer): Boolean; virtual;
     procedure SaveFieldsToBuf(ProtoBuf: TProtoBufOutput); virtual;
+    procedure SaveMessageFieldToBuf(AField: TAbstractProtoBufClass; AFieldNumber: Integer; AFieldProtoBufOutput, AMainProtoBufOutput: TProtoBufOutput);
   public
     constructor Create; virtual;
     destructor Destroy; override;
@@ -264,6 +265,15 @@ procedure TAbstractProtoBufClass.SaveFieldsToBuf(ProtoBuf: TProtoBufOutput);
 begin
   if not AllRequiredFieldsValid then
     raise EStreamError.CreateFmt('Saving %s: not all required fields have been set', [ClassName]);
+end;
+
+procedure TAbstractProtoBufClass.SaveMessageFieldToBuf(
+  AField: TAbstractProtoBufClass; AFieldNumber: Integer;
+  AFieldProtoBufOutput, AMainProtoBufOutput: TProtoBufOutput);
+begin
+  AFieldProtoBufOutput.Clear;
+  AField.SaveToBuf(AFieldProtoBufOutput);
+  AMainProtoBufOutput.writeMessage(AFieldNumber, AFieldProtoBufOutput);
 end;
 
 procedure TAbstractProtoBufClass.SaveToBuf(ProtoBuf: TProtoBufOutput);


### PR DESCRIPTION
These 2 commits fix a critical bug in generated SaveFieldsToBuf methods where tmpBuf is nowadays reused but was not cleared before writing a new subfield or list of integers.