### PR TITLE
Feature: hierarchical structure of protofiles

### DIFF
--- a/Generator/uProtoBufParserAbstractClasses.pas
+++ b/Generator/uProtoBufParserAbstractClasses.pas
@@ -9,8 +9,10 @@ uses
 type
   TAbstractProtoBufParserItem = class(TObject)
   protected
+    FPackage: string;
     FName: string;
     FRoot: TAbstractProtoBufParserItem;
+    FRootPath: string;
     FComments: TStringList;
   public
     constructor Create(ARoot: TAbstractProtoBufParserItem); virtual;
@@ -19,7 +21,9 @@ type
     procedure ParseFromProto(const Proto: string; var iPos: Integer); virtual; abstract;
     procedure AddCommentsToBeginning(AComments: TStringList);
 
+    property RootPath: string read FRootPath write FRootPath;
     property Name: string read FName write FName;
+    property Package: string read FPackage write FPackage;
     property Comments: TStringList read FComments;
   end;
 

--- a/Generator/uProtoBufParserClasses.pas
+++ b/Generator/uProtoBufParserClasses.pas
@@ -730,6 +730,8 @@ var
   OldFileName: string;
   OldName: string;
   sFileName: string;
+const
+  cIncludePathDelimiter = '/';
 begin
   if FFileName = '' then
     raise EParserError.CreateFmt('Cant import from %s, because source .proto file name not specified', [AFileName]);
@@ -737,7 +739,8 @@ begin
   try
     SL := TStringList.Create;
     try
-      sFileName := RelToAbs(AFileName, ExtractFilePath(FFileName));
+      sFileName := FName.Replace('.', cIncludePathDelimiter);
+      sFileName := FRootPath + AFileName.Replace(cIncludePathDelimiter, PathDelim);
       SL.LoadFromFile(sFileName);
 
       OldFileName := FFileName;
@@ -795,7 +798,9 @@ begin
 
         if Buf = 'package' then
           begin
-            FName := ReadWordFromBuf(Proto, iPos, [';']);
+            FPackage := ReadWordFromBuf(Proto, iPos, [';']);
+            FName := Format('%s.%s', [FPackage, FName]);
+            FRootPath := ExtractFilePath(FFileName).Replace(FPackage.Replace('.', PathDelim), '');
             SkipRequiredChar(Proto, iPos, ';');
             TempComments.Clear;
           end;

--- a/Generator/ufmMain.dfm
+++ b/Generator/ufmMain.dfm
@@ -2,69 +2,94 @@ object fmMain: TfmMain
   Left = 0
   Top = 0
   Caption = 'ProtoBufGenerator'
-  ClientHeight = 154
-  ClientWidth = 458
+  ClientHeight = 131
+  ClientWidth = 491
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   OnClose = FormClose
   OnCreate = FormCreate
   DesignSize = (
-    458
-    154)
-  PixelsPerInch = 96
+    491
+    131)
   TextHeight = 13
+  object lblInput: TLabel
+    Left = 8
+    Top = 5
+    Width = 83
+    Height = 13
+    Caption = 'Proto File/Folder:'
+  end
+  object lblOutput: TLabel
+    Left = 8
+    Top = 50
+    Width = 69
+    Height = 13
+    Caption = 'Output folder:'
+  end
   object edProtoFileName: TEdit
     Left = 8
-    Top = 16
-    Width = 409
+    Top = 23
+    Width = 377
     Height = 21
     Anchors = [akLeft, akTop, akRight]
     TabOrder = 0
     TextHint = 'Choose proto file'
   end
   object btnOpenProtoFile: TButton
-    Left = 423
-    Top = 14
-    Width = 27
+    Left = 391
+    Top = 21
+    Width = 35
     Height = 25
     Anchors = [akTop, akRight]
-    Caption = '...'
+    Caption = 'File'
     TabOrder = 1
     OnClick = btnOpenProtoFileClick
   end
   object btnGenerate: TButton
     Left = 8
-    Top = 80
-    Width = 442
-    Height = 66
-    Anchors = [akLeft, akTop, akRight, akBottom]
+    Top = 97
+    Width = 475
+    Height = 34
+    Anchors = [akLeft, akRight, akBottom]
     Caption = 'Generate'
     TabOrder = 2
     OnClick = btnGenerateClick
+    ExplicitWidth = 442
   end
   object edOutputFolder: TEdit
     Left = 8
-    Top = 53
-    Width = 409
+    Top = 69
+    Width = 442
     Height = 21
     Anchors = [akLeft, akTop, akRight]
     TabOrder = 3
     TextHint = 'Choose output folder'
+    ExplicitWidth = 409
   end
   object btnChooseOutputFolder: TButton
-    Left = 423
-    Top = 51
+    Left = 456
+    Top = 66
     Width = 27
     Height = 25
     Anchors = [akTop, akRight]
     Caption = '...'
     TabOrder = 4
     OnClick = btnChooseOutputFolderClick
+    ExplicitLeft = 423
+  end
+  object btnChooseProtoInputFolder: TButton
+    Left = 432
+    Top = 21
+    Width = 51
+    Height = 25
+    Anchors = [akTop, akRight]
+    Caption = 'Folder'
+    TabOrder = 5
+    OnClick = btnChooseProtoInputFolderClick
   end
   object odProtoFile: TFileOpenDialog
     DefaultExtension = '.proto'

--- a/Generator/ufmMain.dfm
+++ b/Generator/ufmMain.dfm
@@ -19,9 +19,9 @@ object fmMain: TfmMain
   object lblInput: TLabel
     Left = 8
     Top = 5
-    Width = 83
+    Width = 96
     Height = 13
-    Caption = 'Proto File/Folder:'
+    Caption = 'Proto File(s)/Folder:'
   end
   object lblOutput: TLabel
     Left = 8
@@ -37,7 +37,7 @@ object fmMain: TfmMain
     Height = 21
     Anchors = [akLeft, akTop, akRight]
     TabOrder = 0
-    TextHint = 'Choose proto file'
+    TextHint = 'Choose proto file(s) or a folder'
   end
   object btnOpenProtoFile: TButton
     Left = 391

--- a/Generator/ufmMain.pas
+++ b/Generator/ufmMain.pas
@@ -23,11 +23,15 @@ type
     btnGenerate: TButton;
     edOutputFolder: TEdit;
     btnChooseOutputFolder: TButton;
+    lblInput: TLabel;
+    lblOutput: TLabel;
+    btnChooseProtoInputFolder: TButton;
     procedure btnOpenProtoFileClick(Sender: TObject);
     procedure btnChooseOutputFolderClick(Sender: TObject);
     procedure btnGenerateClick(Sender: TObject);
     procedure FormClose(Sender: TObject; var Action: TCloseAction);
     procedure FormCreate(Sender: TObject);
+    procedure btnChooseProtoInputFolderClick(Sender: TObject);
   private
     { Private declarations }
     procedure Generate(SourceFiles: TStrings; const OutputDir: string);
@@ -55,6 +59,27 @@ begin
   Dir := edOutputFolder.Text;
   if SelectDirectory('Select output directory', '', Dir, [sdNewFolder, sdShowShares, sdNewUI, sdValidateDir], nil) then
     edOutputFolder.Text := Dir;
+end;
+
+procedure TfmMain.btnChooseProtoInputFolderClick(Sender: TObject);
+var
+  LFileList: TArray<string>;
+  i: Integer;
+begin
+  odProtoFile.Options := odProtoFile.Options + [fdoPickFolders];
+  if odProtoFile.Execute then
+  begin
+    edProtoFileName.Text := '';
+    LFileList := TDirectory.GetFiles(odProtoFile.FileName,'*.proto', TSearchOption.soAllDirectories);
+    for i := 0 to Length(LFileList) -1 do
+    begin
+      edProtoFileName.Text := edProtoFileName.Text + LFileList[i];
+      if i <> Length(LFileList) -1 then
+        edProtoFileName.Text := edProtoFileName.Text + odProtoFile.Files.Delimiter;
+    end;
+
+  end;
+  odProtoFile.Options := odProtoFile.Options - [fdoPickFolders];
 end;
 
 procedure TfmMain.btnGenerateClick(Sender: TObject);


### PR DESCRIPTION
in this pull request hierarchical structure of proto files will be adressed. 
its a follow-up pull request of https://github.com/kami-soft/ProtoBufGenerator/pull/12

For example: 
companyname/product/proto/x.proto
```
syntax = "proto3";
package companyname.product.proto;

import "companyname/product/proto/sample_data/y.proto";

message SampleData{
    sample_data.Y y = 1;
}
```


companyname/product/proto/sample_data/y.proto
```
syntax = "proto3";
package companyname.product.proto.sample_data;
message Y {
    message Test {
        int32 low = 1;
    }

    Test test = 1;
}
```

